### PR TITLE
Add satellite imagery for multiple regions

### DIFF
--- a/src/intel.php
+++ b/src/intel.php
@@ -98,6 +98,37 @@ $intel_data = getIntelData($target_ip);
         </div>
         <button class="toggle-button" onclick="runAll()">Execute all...</button>
 
+        <h2>Settings</h2>
+        <div id="settings-section">
+            <div style="margin-bottom: 15px;">
+                <label style="font-weight: 600;">Satellite Region:</label>
+                <div style="margin-top: 8px;">
+                    <label class="radio-label"><input type="radio" name="region" value="conus" onchange="updateSatelliteRegion('conus')"> CONUS (USA)</label>
+                    <label class="radio-label"><input type="radio" name="region" value="mexico" onchange="updateSatelliteRegion('mexico')"> Mexico</label>
+                    <label class="radio-label"><input type="radio" name="region" value="canada" onchange="updateSatelliteRegion('canada')"> Canada</label>
+                    <label class="radio-label"><input type="radio" name="region" value="europe" onchange="updateSatelliteRegion('europe')"> Europe</label>
+                    <label class="radio-label"><input type="radio" name="region" value="china" onchange="updateSatelliteRegion('china')"> China</label>
+                </div>
+                <button class="toggle-button" onclick="useCurrentLocation()" style="margin-top: 10px;">Use current location</button>
+            </div>
+        </div>
+
+        <h2>Satellite</h2>
+        <div id="satellite-section">
+            <div id="satellite-controls" style="margin-bottom: 15px;">
+                <label style="font-weight: 600;">Image Type:</label>
+                <div style="margin-top: 8px;">
+                    <label class="radio-label"><input type="radio" name="imageType" value="geocolor" checked onchange="updateSatelliteImage()"> GeoColor</label>
+                    <label class="radio-label"><input type="radio" name="imageType" value="vis" onchange="updateSatelliteImage()"> Visible</label>
+                    <label class="radio-label"><input type="radio" name="imageType" value="ir" onchange="updateSatelliteImage()"> Infrared</label>
+                    <label class="radio-label"><input type="radio" name="imageType" value="wv" onchange="updateSatelliteImage()"> Water Vapor</label>
+                </div>
+            </div>
+            <div id="satellite-image-container" style="text-align: center; background: #f0f0f0; padding: 20px; border-radius: 5px;">
+                <p style="color: #666;">Select a region in Settings to view satellite imagery</p>
+            </div>
+        </div>
+
         <h2>nmap scan</h2>
         <div id="scan-buttons">
             <button class="toggle-button green" onclick="runScan('quick')">Quick port scan</button>

--- a/src/intel/intel.js
+++ b/src/intel/intel.js
@@ -208,3 +208,172 @@ function runAll() {
     runTrace();
     runWhois(targetIP);
 }
+
+// Satellite imagery configuration
+const satelliteConfig = {
+    conus: {
+        name: 'CONUS (USA)',
+        geocolor: 'https://cdn.star.nesdis.noaa.gov/GOES16/ABI/CONUS/GEOCOLOR/latest.jpg',
+        vis: 'https://cdn.star.nesdis.noaa.gov/GOES16/ABI/CONUS/02/latest.jpg',
+        ir: 'https://cdn.star.nesdis.noaa.gov/GOES16/ABI/CONUS/13/latest.jpg',
+        wv: 'https://cdn.star.nesdis.noaa.gov/GOES16/ABI/CONUS/09/latest.jpg',
+        available: ['geocolor', 'vis', 'ir', 'wv']
+    },
+    mexico: {
+        name: 'Mexico',
+        geocolor: 'https://cdn.star.nesdis.noaa.gov/GOES16/ABI/SECTOR/mex/GEOCOLOR/latest.jpg',
+        vis: 'https://cdn.star.nesdis.noaa.gov/GOES16/ABI/SECTOR/mex/02/latest.jpg',
+        ir: 'https://cdn.star.nesdis.noaa.gov/GOES16/ABI/SECTOR/mex/13/latest.jpg',
+        wv: 'https://cdn.star.nesdis.noaa.gov/GOES16/ABI/SECTOR/mex/09/latest.jpg',
+        available: ['geocolor', 'vis', 'ir', 'wv']
+    },
+    canada: {
+        name: 'Canada',
+        geocolor: 'https://cdn.star.nesdis.noaa.gov/GOES16/ABI/SECTOR/can/GEOCOLOR/latest.jpg',
+        vis: 'https://cdn.star.nesdis.noaa.gov/GOES16/ABI/SECTOR/can/02/latest.jpg',
+        ir: 'https://cdn.star.nesdis.noaa.gov/GOES16/ABI/SECTOR/can/13/latest.jpg',
+        wv: 'https://cdn.star.nesdis.noaa.gov/GOES16/ABI/SECTOR/can/09/latest.jpg',
+        available: ['geocolor', 'vis', 'ir', 'wv']
+    },
+    europe: {
+        name: 'Europe',
+        geocolor: null,
+        vis: 'https://eumetview.eumetsat.int/static-images/latestImages/EUMETSAT_MSG_RGBNatColourEnhncd_LowResolution_Europe.jpg',
+        ir: 'https://eumetview.eumetsat.int/static-images/latestImages/EUMETSAT_MSG_IR108_LowResolution_Europe.jpg',
+        wv: 'https://eumetview.eumetsat.int/static-images/latestImages/EUMETSAT_MSG_WV062_LowResolution_Europe.jpg',
+        available: ['vis', 'ir', 'wv']
+    },
+    china: {
+        name: 'China',
+        geocolor: 'https://himawari8.nict.go.jp/img/D531106/latest.jpg',
+        vis: 'https://himawari8.nict.go.jp/img/D531106/latest.jpg',
+        ir: null,
+        wv: null,
+        available: ['geocolor', 'vis']
+    }
+};
+
+let currentRegion = null;
+let regionSelectDisabled = false;
+
+function updateSatelliteRegion(region) {
+    if (regionSelectDisabled) return;
+
+    currentRegion = region;
+    const config = satelliteConfig[region];
+
+    // Update available image type options
+    const imageTypeInputs = document.querySelectorAll('input[name="imageType"]');
+    imageTypeInputs.forEach(input => {
+        const imageType = input.value;
+        const label = input.parentElement;
+
+        if (config.available.includes(imageType)) {
+            input.disabled = false;
+            label.style.opacity = '1';
+            label.style.cursor = 'pointer';
+        } else {
+            input.disabled = true;
+            label.style.opacity = '0.4';
+            label.style.cursor = 'not-allowed';
+        }
+    });
+
+    // Select first available image type
+    const firstAvailable = config.available[0];
+    const firstInput = document.querySelector(`input[name="imageType"][value="${firstAvailable}"]`);
+    if (firstInput) {
+        firstInput.checked = true;
+    }
+
+    updateSatelliteImage();
+}
+
+function updateSatelliteImage() {
+    if (!currentRegion) return;
+
+    const selectedImageType = document.querySelector('input[name="imageType"]:checked');
+    if (!selectedImageType) return;
+
+    const imageType = selectedImageType.value;
+    const config = satelliteConfig[currentRegion];
+    const imageUrl = config[imageType];
+
+    const container = document.getElementById('satellite-image-container');
+
+    if (imageUrl) {
+        // Add cache-busting parameter to ensure fresh image
+        const cacheBuster = '?t=' + new Date().getTime();
+        container.innerHTML = `
+            <div style="position: relative;">
+                <img src="${imageUrl}${cacheBuster}"
+                     alt="${config.name} - ${imageType}"
+                     style="max-width: 100%; height: auto; border-radius: 3px; box-shadow: 0 2px 8px rgba(0,0,0,0.1);"
+                     onerror="this.parentElement.innerHTML='<p style=\\'color: #d32f2f;\\'>Failed to load satellite image</p>'">
+                <div style="margin-top: 10px; font-size: 0.9em; color: #666;">
+                    ${config.name} - ${imageType.toUpperCase()}
+                </div>
+            </div>
+        `;
+    } else {
+        container.innerHTML = `<p style="color: #ff9800;">This image type is not available for ${config.name}</p>`;
+    }
+}
+
+function useCurrentLocation() {
+    if (!navigator.geolocation) {
+        alert('Geolocation is not supported by your browser');
+        return;
+    }
+
+    const button = event.target;
+    button.disabled = true;
+    button.textContent = 'Getting location...';
+
+    navigator.geolocation.getCurrentPosition(
+        function(position) {
+            const lat = position.coords.latitude;
+            const lon = position.coords.longitude;
+
+            // Determine region based on coordinates
+            let detectedRegion = 'conus';
+
+            // Simple region detection based on lat/lon bounds
+            if (lat >= 24 && lat <= 50 && lon >= -125 && lon <= -66) {
+                detectedRegion = 'conus';
+            } else if (lat >= 14 && lat <= 33 && lon >= -118 && lon <= -86) {
+                detectedRegion = 'mexico';
+            } else if (lat >= 42 && lat <= 84 && lon >= -141 && lon <= -52) {
+                detectedRegion = 'canada';
+            } else if (lat >= 35 && lat <= 72 && lon >= -10 && lon <= 40) {
+                detectedRegion = 'europe';
+            } else if (lat >= 18 && lat <= 54 && lon >= 73 && lon <= 135) {
+                detectedRegion = 'china';
+            }
+
+            // Disable region selector and select detected region
+            regionSelectDisabled = true;
+            const regionInputs = document.querySelectorAll('input[name="region"]');
+            regionInputs.forEach(input => {
+                input.disabled = true;
+                if (input.value === detectedRegion) {
+                    input.checked = true;
+                }
+            });
+
+            updateSatelliteRegion(detectedRegion);
+
+            button.textContent = 'Location detected: ' + satelliteConfig[detectedRegion].name;
+            button.classList.add('disabled');
+        },
+        function(error) {
+            alert('Unable to retrieve your location: ' + error.message);
+            button.disabled = false;
+            button.textContent = 'Use current location';
+        },
+        {
+            timeout: 10000,
+            enableHighAccuracy: false
+        }
+    );
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -156,6 +156,21 @@ a.header {
     cursor: pointer;
 }
 
+/* Radio label styling */
+.radio-label {
+    display: inline-block;
+    margin-right: 15px;
+    margin-bottom: 8px;
+    font-size: 10pt;
+    cursor: pointer;
+    user-select: none;
+}
+
+.radio-label input[type="radio"] {
+    margin-right: 5px;
+    cursor: pointer;
+}
+
 /* Style tables to have a smaller font size */
 table, th, td {
     border: 3px solid white;


### PR DESCRIPTION
Adds new Satellite and Settings sections to the intel page with support for viewing real-time satellite imagery from multiple regions:
- CONUS (USA) - GOES-16 satellite
- Mexico - GOES-16 satellite
- Canada - GOES-16 satellite
- Europe - EUMETSAT Meteosat
- China - Himawari-8 satellite

Features:
- Region selection with radio buttons in Settings section
- Multiple image types: GeoColor, Visible, Infrared, Water Vapor
- Auto-detection of region based on user's geolocation
- Unavailable image types are greyed out per region
- "Use current location" button to auto-select appropriate region
- Region selector disabled when using current location
- Cache-busting for real-time image updates

Image sources:
- NASA/NOAA GOES satellites via cdn.star.nesdis.noaa.gov
- EUMETSAT Meteosat via eumetview.eumetsat.int
- JMA Himawari-8 via himawari8.nict.go.jp